### PR TITLE
Web UI configuration

### DIFF
--- a/docs/user-guide/examples.md
+++ b/docs/user-guide/examples.md
@@ -2,6 +2,21 @@
 
 You will find here some configuration examples of Træfik.
 
+## Web/API User Interface
+
+This configuration provides one with a quick check to ensure that they can get Traefik up and running.
+It serves the Web UI on port 80, usually some other port such as 8080 is used but one might not realise that this is blocked by ones firewall rules.
+
+```toml
+defaultEntryPoints = ["traefik"]
+[entrypoints.traefik]
+address = ":80"
+[api]
+entryPoint = "traefik"
+dashboard = true
+debug = true
+```
+
 ## HTTP only
 
 ```toml


### PR DESCRIPTION
### What does this PR do?

Provides a minimal configuration for getting the web interface up and running. 

### Motivation

I was having trouble getting the web interface up on my machine, granted I didn't check my IP table rules to realize that I had blocked the default port. (I had been reading HaProxy/NginX/Traefik and Dockergen documentation for the preceeding 48 hours trying to get my own stuff working and was a bit short on sleep)

Either way the API documention does not explain what the `traefik` entrypoint is nor how it is set up and I felt an example might be of use to the next weary netizen.

### More

- [ ] Added/updated documentation

### Additional Notes

I have placed this under the example configuration(s) section but it might be better suited under a different location or simply removed all together. If this is rejected I will make it available upon the Gentoo Wiki in due course, just thought it might be more beneficial here.
